### PR TITLE
24 Nov Sub updates

### DIFF
--- a/_resources/Admission/Appeal Process for Sec 1 Admission.md
+++ b/_resources/Admission/Appeal Process for Sec 1 Admission.md
@@ -15,7 +15,7 @@ variant: markdown
 </tr>
 <tr>
 <td style="text-align: center; width: 415px;">
-<p>22 December 2023, 12:00pm&nbsp;</p>
+<p>Within 3 days after posting results. <br>Exact date to be updated after posting results</p>
 </td>
 </tr>
 </tbody>
@@ -28,5 +28,4 @@ variant: markdown
 <li>Copies of CCA Records&nbsp;</li>
 <li>Other relevant documents.&nbsp;</li>
 </ol>
-<p>Please submit your appeal application by 22 December 2023, 12:00pm.</p>
 <p>More information on admission matters can be found&nbsp;<a href="https://www.moe.gov.sg/faq?categoryid=C547D6C3F9584A80B5634874DBD4423B" target="_blank" rel="noopener">here</a>.</p>

--- a/_resources/Admission/Sec 1 Admission.md
+++ b/_resources/Admission/Sec 1 Admission.md
@@ -9,7 +9,7 @@ variant: markdown
 
 <p><strong><u>Overview of Secondary 1 Posting Exercise</u></strong></p>
 <p>The annual Secondary 1 Posting Exercise is conducted by the Ministry of Education (MOE) to post Primary 6 students from mainstream primary schools who have sat for the Primary School Leaving Examination (PSLE) and are eligible for secondary school. The exercise takes into consideration the students’ PSLE results, choices of schools and availability of vacancies. The posting results will be released between 20 Dec and 22 Dec 2023 (tentative) via online, SMS and through the primary school.</p>
-<p>Students do not need to report to our school after receiving the S1 Posting Results. Parents/guardian of 2023 Secondary 1 students who are successfully posted to our school will be contacted via Parent Gateway for registration details. For more information, please refer to the <a href="https://www.moe.gov.sg/news/press-releases/20231122-release-of-2023-psle-results#:~:text=The%20S1%20Posting%20Results%20will,applicant%20during%20the%20application%20process">MOE website</a>.&nbsp;</p>
+<p>Students do not need to report to our school after receiving the S1 Posting Results. Parents/guardian of 2024 Secondary 1 students who are successfully posted to our school will be contacted via Parent Gateway for registration details. For more information, please refer to the <a href="https://www.moe.gov.sg/news/press-releases/20231122-release-of-2023-psle-results#:~:text=The%20S1%20Posting%20Results%20will,applicant%20during%20the%20application%20process">MOE website</a>.&nbsp;</p>
 <br>
 <br>
 <table>


### PR DESCRIPTION
Changed the "Parents/guardian of 2023 Secondary 1 students" to "Parents/guardian of 2024 Secondary 1 students" in Sec 1 Admission page.
Updated the "22 December 2023, 12:00pm" to "Within 3 days after posting results. Exact date to be updated after posting results" in Appeal Process for Sec 1 Admission Page. (Requested by Ms Xu)