### PR TITLE
6 May 2024 Update

### DIFF
--- a/_about-us/Non–Teaching Staff.md
+++ b/_about-us/Non–Teaching Staff.md
@@ -61,12 +61,6 @@ variant: markdown
 <div>STEM Instructor (Laboratory)</div>
 </td>
 </tr>
-	<tr>
-<td>Mr Yap Pao Ming</td>
-<td>
-<div>STEM Instructor (Laboratory)</div>
-</td>
-</tr>
 <tr>
 <td>Mdm Rohayah Bte Sarpin</td>
 <td>


### PR DESCRIPTION
1. Removed Yap Bao Ming from Non-Teaching Staff page. - Personnel movement.