### PR TITLE
17 April 2025 Update

### DIFF
--- a/_cca/Sports & Games/Sports & Games.md
+++ b/_cca/Sports & Games/Sports & Games.md
@@ -6,6 +6,42 @@ third_nav_title: Sports & Games
 variant: markdown
 ---
 <p>TKGS cultivates determination and excellence in our student-athletes. Our diverse teams consistently shine at the National School Games, showcasing remarkable skill and sportsmanship. Through rigorous training and competition, we nurture both athletic prowess and character, preparing our students for success on and off the field.</p>
+<h3>Year 2025</h3>
+<table>
+<tbody>
+	<tr>
+	<th style="text-align: center;">CCA</th>
+	<th style="text-align: center;">Competition</th>
+	<th style="text-align: center;">Result</th>
+		</tr>
+			<tr>
+			<td style="vertical-align: middle; text-align: center;">Badminton</td>
+			<td style="vertical-align: middle; text-align: center;">East Zone 'B' Division</td>
+			<td style="vertical-align: middle; text-align: center;">3rd Position</td>
+	</tr>
+	<tr>
+			<td style="vertical-align: middle; text-align: center;">Bowling</td>
+			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division</td>
+			<td style="vertical-align: middle; text-align: center;">3rd Position</td>
+	</tr>
+		<tr>
+			<td style="vertical-align: middle; text-align: center;">Floorball</td>
+			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division</td>
+			<td style="vertical-align: middle; text-align: center;">2nd Position</td>
+	</tr>
+	<tr>
+			<td style="vertical-align: middle; text-align: center;">Netball</td>
+			<td style="vertical-align: middle; text-align: center;">East Zone 'B' Division</td>
+			<td style="vertical-align: middle; text-align: center;">3rd Position</td>
+	</tr>
+	<tr>
+			<td style="vertical-align: middle; text-align: center;">Softball</td>
+			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division</td>
+			<td style="vertical-align: middle; text-align: center;">3rd Position</td>
+	</tr>
+</tbody>
+</table>
+
 <h3>Year 2024</h3>
 <table>
 <tbody>
@@ -30,7 +66,7 @@ variant: markdown
 	</tr>
 	<tr>
 			<td style="vertical-align: middle; text-align: center;">Floorball</td>
-			<td style="vertical-align: middle; text-align: center;">National School Games<br>(League 1)</td>
+			<td style="vertical-align: middle; text-align: center;">National ‘C’ Division<br> League 1</td>
 			<td style="vertical-align: middle; text-align: center;">Champion</td>
 	</tr>
 	<tr>
@@ -86,39 +122,6 @@ variant: markdown
 			<td style="vertical-align: middle; text-align: center;">Softball</td>
 			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division School Games</td>
 			<td style="vertical-align: middle; text-align: center;">3rd Position</td>
-	</tr>
-	</tbody>
-</table>
-<h3>Year 2022</h3><table>
-<tbody>
-	<tr>
-	<th style="text-align: center;">CCA</th>
-	<th style="text-align: center;">Competition</th>
-	<th style="text-align: center;">Result</th>
-		</tr>
-		<tr>
-			<td style="vertical-align: middle; text-align: center;"> Badminton</td>
-			<td style="vertical-align: middle; text-align: center;">East Zone 'B' Division School Games</td>
-			<td style="vertical-align: middle; text-align: center;">3rd Position</td>
-	</tr>
-		<tr>
-			<td style="vertical-align: middle; text-align: center;">Netball</td>
-			<td style="vertical-align: middle; text-align: center;">East Zone 'C' Division School Games</td>
-			<td style="vertical-align: middle; text-align: center;">Champion</td>
-	</tr>
-	<tr>
-			<td style="vertical-align: middle; text-align: center;">Softball</td>
-			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division School Games</td>
-			<td style="vertical-align: middle; text-align: center;">4th Position</td>
-	</tr>
-	<tr>
-			<td style="vertical-align: middle; text-align: center;" rowspan="2">Bowling</td>
-			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division School Games</td>
-			<td style="vertical-align: middle; text-align: center;">3rd Position</td>
-	</tr>
-	<tr>
-		<td style="vertical-align: middle; text-align: center;">National ‘C’ Division School Games</td>
-			<td style="vertical-align: middle; text-align: center;">2nd Position</td>
 	</tr>
 	</tbody>
 </table>

--- a/_cca/Sports & Games/Sports & Games.md
+++ b/_cca/Sports & Games/Sports & Games.md
@@ -128,6 +128,11 @@ variant: markdown
 			<td style="vertical-align: middle; text-align: center;">3rd Position</td>
 	</tr>
 	<tr>
+			<td style="vertical-align: middle; text-align: center;">Sailing</td>
+			<td style="vertical-align: middle; text-align: center;">National ‘C’ Division <br>Optimist</td>
+			<td style="vertical-align: middle; text-align: center;">2nd Position</td>
+	</tr>
+	<tr>
 			<td style="vertical-align: middle; text-align: center;">Softball</td>
 			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division</td>
 			<td style="vertical-align: middle; text-align: center;">3rd Position</td>

--- a/_cca/Sports & Games/Sports & Games.md
+++ b/_cca/Sports & Games/Sports & Games.md
@@ -52,16 +52,16 @@ variant: markdown
 		</tr>
 			<tr>
 			<td style="vertical-align: middle; text-align: center;">Basketball</td>
-			<td style="vertical-align: middle; text-align: center;">National 'C' Division School Games<br>(League 3)</td>
+			<td style="vertical-align: middle; text-align: center;">National 'C' Division<br>League 3</td>
 			<td style="vertical-align: middle; text-align: center;">2nd Position</td>
 	</tr>
 	<tr>
 			<td style="vertical-align: middle; text-align: center;" rowspan="2">Bowling</td>
-			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division School Games</td>
+			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division</td>
 			<td style="vertical-align: middle; text-align: center;">3rd Position</td>
 	</tr>
 		<tr>
-			<td style="vertical-align: middle; text-align: center;">National ‘C’ Division School Games</td>
+			<td style="vertical-align: middle; text-align: center;">National ‘C’ Division</td>
 			<td style="vertical-align: middle; text-align: center;">2nd Position</td>
 	</tr>
 	<tr>
@@ -71,16 +71,25 @@ variant: markdown
 	</tr>
 	<tr>
 			<td style="vertical-align: middle; text-align: center;" rowspan="2">Netball</td>
-			<td style="vertical-align: middle; text-align: center;">East Zone 'B' Division School Games</td>
+			<td style="vertical-align: middle; text-align: center;">East Zone 'B' Division</td>
 			<td style="vertical-align: middle; text-align: center;">2nd Position</td>
 	</tr>
 	<tr>
-			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division School Games</td>
+			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division</td>
 			<td style="vertical-align: middle; text-align: center;">Top 8</td>
 	</tr>
 	<tr>
+			<td style="vertical-align: middle; text-align: center;" rowspan="2">Sailing</td>
+			<td style="vertical-align: middle; text-align: center;">National ‘C’ Division <br>(Optimist)</td>
+			<td style="vertical-align: middle; text-align: center;">2nd Position</td>
+	</tr>
+	<tr>
+			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division (ILCA4)</td>
+			<td style="vertical-align: middle; text-align: center;">Champion</td>
+	</tr>
+	<tr>
 			<td style="vertical-align: middle; text-align: center;">Softball</td>
-			<td style="vertical-align: middle; text-align: center;">National ‘C’ Division School Games<br>(League 1)</td>
+			<td style="vertical-align: middle; text-align: center;">National ‘C’ Division<br>League 1</td>
 			<td style="vertical-align: middle; text-align: center;">4th Position</td>
 	</tr>
 </tbody>
@@ -90,37 +99,37 @@ variant: markdown
 <tbody>
 <tr>
 			<td style="vertical-align: middle; text-align: center;">Badminton</td>
-			<td style="vertical-align: middle; text-align: center;">East Zone 'C' Division School Games</td>
+			<td style="vertical-align: middle; text-align: center;">East Zone 'C' Division</td>
 			<td style="vertical-align: middle; text-align: center;">4th Position</td>
 	</tr>
 	<tr>
 			<td style="vertical-align: middle; text-align: center;" rowspan="2">Bowling</td>
-			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division School Games</td>
+			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division</td>
 			<td style="vertical-align: middle; text-align: center;">3rd Position</td>
 	</tr><tr>
-			<td style="vertical-align: middle; text-align: center;">National ‘C’ Division School Games</td>
+			<td style="vertical-align: middle; text-align: center;">National ‘C’ Division</td>
 			<td style="vertical-align: middle; text-align: center;">2nd Position</td>
 	</tr>
 	<tr>
 			<td style="vertical-align: middle; text-align: center;" rowspan="4">Netball</td>
-			<td style="vertical-align: middle; text-align: center;">East Zone 'B' Division School Games</td>
+			<td style="vertical-align: middle; text-align: center;">East Zone 'B' Division</td>
 			<td style="vertical-align: middle; text-align: center;">Champion</td>
 	</tr>
 	<tr>
-			<td style="vertical-align: middle; text-align: center;">East Zone 'C' Division School Games</td>
+			<td style="vertical-align: middle; text-align: center;">East Zone 'C' Division</td>
 			<td style="vertical-align: middle; text-align: center;">4th Position</td>
 	</tr>
 	<tr>
-			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division School Games</td>
+			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division</td>
 			<td style="vertical-align: middle; text-align: center;">3rd Position</td>
 	</tr>
 	<tr>
-			<td style="vertical-align: middle; text-align: center;">National ‘C’ Division School Games</td>
+			<td style="vertical-align: middle; text-align: center;">National ‘C’ Division</td>
 			<td style="vertical-align: middle; text-align: center;">3rd Position</td>
 	</tr>
 	<tr>
 			<td style="vertical-align: middle; text-align: center;">Softball</td>
-			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division School Games</td>
+			<td style="vertical-align: middle; text-align: center;">National ‘B’ Division</td>
 			<td style="vertical-align: middle; text-align: center;">3rd Position</td>
 	</tr>
 	</tbody>

--- a/_cca/Uniformed Groups/Uniformed Groups.md
+++ b/_cca/Uniformed Groups/Uniformed Groups.md
@@ -6,6 +6,26 @@ third_nav_title: Uniformed Groups
 variant: markdown
 ---
 <p>TKGS Uniformed Groups embody discipline, determination, and teamwork. Our students develop crucial life skills including leadership, resilience and strategic thinking. Through rigorous training and learning experiences, they cultivate a strong sense of civic responsibility, character and values.</p>
+<h3>Year 2024</h3><table>
+<tbody>
+	<tr>
+	<th style="text-align: center;">CCA</th>
+	<th style="text-align: center;">Competition</th>
+	<th style="text-align: center;">Result</th>
+		</tr>
+		<tr>
+			<td style="vertical-align: middle; text-align: center;">National Police Cadet Corp</td>
+			<td style="vertical-align: middle; text-align: center;">Unit Overall Proficiency Award</td>
+			<td style="vertical-align: middle; text-align: center;">Distinction</td>
+	</tr>
+	<tr>
+			<td style="vertical-align: middle; text-align: center;">Red Cross Youth</td>
+			<td style="vertical-align: middle; text-align: center;">Excellent Unit Award</td>
+			<td style="vertical-align: middle; text-align: center;">Gold</td>
+	</tr>
+	</tbody>
+</table>
+
 <h3>Year 2023</h3><table>
 <tbody>
 	<tr>
@@ -49,29 +69,6 @@ variant: markdown
 			<td style="vertical-align: middle; text-align: center;">Red Cross Youth</td>
 			<td style="vertical-align: middle; text-align: center;">Excellent Unit Award</td>
 			<td style="vertical-align: middle; text-align: center;">Gold</td>
-	</tr>
-	</tbody>
-</table>
-<h3>Year 2021</h3><table>
-<tbody>
-	<tr>
-	<th style="text-align: center;">CCA</th>
-	<th style="text-align: center;">Competition</th>
-	<th style="text-align: center;">Result</th>
-		</tr>
-		<tr>
-			<td style="vertical-align: middle; text-align: center;">Girl Guides</td>
-			<td style="vertical-align: middle; text-align: center;">Puan Noor Aisha Award</td>
-			<td style="vertical-align: middle; text-align: center;">Gold</td>
-	</tr><tr>
-			<td style="vertical-align: middle; text-align: center;">National Police Cadet Corp</td>
-			<td style="vertical-align: middle; text-align: center;">Unit Overall Proficiency Award</td>
-			<td style="vertical-align: middle; text-align: center;">Gold</td>
-	</tr>
-	<tr>
-			<td style="vertical-align: middle; text-align: center;">Red Cross Youth</td>
-			<td style="vertical-align: middle; text-align: center;">Excellent Unit Award</td>
-			<td style="vertical-align: middle; text-align: center;">Sliver</td>
 	</tr>
 	</tbody>
 </table>

--- a/_cca/Uniformed Groups/Uniformed Groups.md
+++ b/_cca/Uniformed Groups/Uniformed Groups.md
@@ -62,7 +62,7 @@ variant: markdown
 			<td style="vertical-align: middle; text-align: center;">Gold</td>
 	</tr><tr>
 			<td style="vertical-align: middle; text-align: center;">National Police Cadet Corp</td>
-			<td style="vertical-align: middle;">Unit Overall Proficiency Award</td>
+			<td style="vertical-align: middle; text-align: center;">Unit Overall Proficiency Award</td>
 			<td style="vertical-align: middle; text-align: center;">Distinction</td>
 	</tr>
 	<tr>

--- a/_cca/Visual & Performing Arts/Visual & Performing Arts.md
+++ b/_cca/Visual & Performing Arts/Visual & Performing Arts.md
@@ -25,7 +25,7 @@ variant: markdown
 </tr>
 </tbody>
 </table>
-<h3>Singapore Youth Festival Arts Presentation 2023</h3>
+<h3>Year 2023</h3>
 <table>
 <tbody>
 <tr>
@@ -34,27 +34,27 @@ variant: markdown
 </tr>
 <tr>
 <td style="vertical-align: middle; text-align: center;">Choir</td>
-<td style="vertical-align: middle; text-align: center;">Certificate of Distinction</td>
+<td style="vertical-align: middle; text-align: center;">SYF Certificate of Distinction</td>
 </tr>
 <tr>
 <td style="vertical-align: middle; text-align: center;">Dance (Modern)</td>
-<td style="vertical-align: middle; text-align: center;">Certificate of Distinction</td>
+<td style="vertical-align: middle; text-align: center;">SYF Certificate of Distinction</td>
 </tr>
 <tr>
 <td style="vertical-align: middle; text-align: center;">Drama</td>
-<td style="vertical-align: middle; text-align: center;">Certificate of Distinction</td>
+<td style="vertical-align: middle; text-align: center;">SYF Certificate of Distinction</td>
 </tr>
 <tr>
 <td style="vertical-align: middle; text-align: center;">String Ensemble</td>
-<td style="vertical-align: middle; text-align: center;">Certificate of Distinction</td>
+<td style="vertical-align: middle; text-align: center;">SYF Certificate of Distinction</td>
 </tr>
 <tr>
 <td style="vertical-align: middle; text-align: center;">Symphonic Band</td>
-<td style="vertical-align: middle; text-align: center;">Certificate of Accomplishment</td>
+<td style="vertical-align: middle; text-align: center;">SYF Certificate of Accomplishment</td>
 </tr>
 </tbody>
 </table>
-<h3>Singapore Youth Festival Arts Presentation 2021</h3>
+<h3>Year 2021</h3>
 <table>
 <tbody>
 <tr>
@@ -67,19 +67,19 @@ variant: markdown
 </tr>
 <tr>
 <td style="vertical-align: middle; text-align: center;">Dance (Modern)</td>
-<td style="vertical-align: middle; text-align: center;">Certificate of Distinction</td>
+<td style="vertical-align: middle; text-align: center;">SYF Certificate of Distinction</td>
 </tr>
 <tr>
 <td style="vertical-align: middle; text-align: center;">Drama</td>
-<td style="vertical-align: middle; text-align: center;">Certificate of Distinction</td>
+<td style="vertical-align: middle; text-align: center;">SYF Certificate of Distinction</td>
 </tr>
 <tr>
 <td style="vertical-align: middle; text-align: center;">String Ensemble</td>
-<td style="vertical-align: middle; text-align: center;">Certificate of Distinction</td>
+<td style="vertical-align: middle; text-align: center;">SYF Certificate of Distinction</td>
 </tr>
 <tr>
 <td style="vertical-align: middle; text-align: center;">Symphonic Band</td>
-<td style="vertical-align: middle; text-align: center;">Certificate of Distinction</td>
+<td style="vertical-align: middle; text-align: center;">SYF Certificate of Distinction</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
1. Added Year 2025 S&G achievements to Sports & Games page.
2. Removed Year 2022 achievements from Sports & Games page.
3. Removed the term "School Games" from Sports & Games page.
4. Updated the header for each year in Visual & Performing Arts page.
5. Added "SYF" to various achievements awarded during SYF in Visual & Performing Arts page.
5. Added Year 2024 UG achievements to Uniform Groups page.